### PR TITLE
Adding support for rows defined on several lines - solves #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,12 @@ test: lint
 
 coverage:
 	rm -rf coverage
-	${MODULE_PATH}/istanbul cover node_modules/.bin/_mocha
+	${MODULE_PATH}/istanbul cover ${MODULE_PATH}/.bin/_mocha
 
 test-ci: lint
-	${MODULE_PATH}/istanbul cover ${MODULE_PATH}/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ${MODULE_PATH}/coveralls && rm -rf ./coverage
+	${MODULE_PATH}/istanbul cover ${MODULE_PATH}/_mocha --report lcovonly -- -R spec
+	cat ./coverage/lcov.info | ${MODULE_PATH}/coveralls
+	rm -rf ./coverage
 
 browserify:
 	rm -rf ./dist

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function multimd_table_plugin(md, pluginOptions) {
     emptyCount = 0;
     colspans = [];
     for (i = columns.length - 1; i >= 0; i--) {
-      if (columns[i].trim()) {
+      if (columns[i]) {
         colspans.unshift(emptyCount + 1);
         emptyCount = 0;
       } else {
@@ -126,13 +126,14 @@ module.exports = function multimd_table_plugin(md, pluginOptions) {
       if (nextColumn.length === 1 && !/^\||[^\\]\|$/.test(nextLineText)) { return false; }
       if (nextColumn.length !== columns.length && nextColumn.length !== columns.length - 1) { return false; }
       for (i = 0; i < nextColumn.length; i++) {
-        columns[i] = columns[i].replace(/^\s+/, '').replace(/ +(\n*)$/, '$1') + '\n' + nextColumn[i].trim();
+        columns[i] = columns[i].trim() + '\n' + nextColumn[i].trim();
       }
       rowInfo.extractedTextLinesCount += 1;
     }
 
-    rowInfo.columns = columns.filter(Boolean);
-    rowInfo.colspans = countColspan(columns);
+    isValidColumn = RegExp.prototype.test.bind(/[^\n]/); // = (s => /[^\n]/.test(s))
+    rowInfo.columns = columns.filter(isValidColumn);
+    rowInfo.colspans = countColspan(columns.map(isValidColumn));
 
     token     = state.push('tr_open', 'tr', 1);
     token.map = [ lineNum, lineNum + rowInfo.extractedTextLinesCount ];

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = function multimd_table_plugin(md, pluginOptions) {
   }
 
   function tableRow(state, lineText, lineNum, silent, separatorInfo, rowType) {
-    var rowInfo, columns, nextLineText, nextColumn, token, i, col;
+    var rowInfo, columns, nextLineText, nextColumn, token, i, col, isValidColumn;
     rowInfo = { colspans: null, columns: null, extractedTextLinesCount: 1 };
 
     columns = escapedSplit(lineText.replace(/^\||([^\\])\|$/g, '$1'));

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function multimd_table_plugin(md, pluginOptions) {
     emptyCount = 0;
     colspans = [];
     for (i = columns.length - 1; i >= 0; i--) {
-      if (columns[i]) {
+      if (columns[i].trim()) {
         colspans.unshift(emptyCount + 1);
         emptyCount = 0;
       } else {
@@ -126,7 +126,7 @@ module.exports = function multimd_table_plugin(md, pluginOptions) {
       if (nextColumn.length === 1 && !/^\||[^\\]\|$/.test(nextLineText)) { return false; }
       if (nextColumn.length !== columns.length && nextColumn.length !== columns.length - 1) { return false; }
       for (i = 0; i < nextColumn.length; i++) {
-        columns[i] = columns[i].replace(/^\s+| +$/, '') + '\n' + nextColumn[i].trim();
+        columns[i] = columns[i].replace(/^\s+/, '').replace(/ +(\n*)$/, '$1') + '\n' + nextColumn[i].trim();
       }
       rowInfo.extractedTextLinesCount += 1;
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = function multimd_table_plugin(md) {
+module.exports = function multimd_table_plugin(md, pluginOptions) {
+  pluginOptions = pluginOptions || {};
+
   function getLine(state, line) {
     var pos = state.bMarks[line] + state.blkIndent,
         max = state.eMarks[line];
@@ -91,30 +93,42 @@ module.exports = function multimd_table_plugin(md) {
     return captionInfo;
   }
 
-  function tableRow(state, lineText, lineNum, silent, seperatorInfo, rowType) {
-    var rowInfo, columns, token, i, col;
+  function tableRow(state, lineText, lineNum, silent, separatorInfo, rowType) {
+    var rowInfo, columns, nextLineText, nextColumn, token, i, col;
+    rowInfo = { colspans: null, columns: null, extractedTextLinesCount: 1 };
 
     columns = escapedSplit(lineText.replace(/^\||([^\\])\|$/g, '$1'));
     // lineText does not contain valid pipe character
     if (columns.length === 1 && !/^\||[^\\]\|$/.test(lineText)) { return false; }
     if (silent) { return true; }
 
-    rowInfo = { colspans: null, columns: null };
+    while (pluginOptions.enableMultilineRows && columns[columns.length - 1].slice(-1) === '\\') {
+      columns[columns.length - 1] = columns[columns.length - 1].slice(0, -1);
+      nextLineText = getLine(state, lineNum + rowInfo.extractedTextLinesCount);
+      nextColumn = escapedSplit(nextLineText.replace(/^\||([^\\])\|$/g, '$1'));
+      if (nextColumn.length === 1 && !/^\||[^\\]\|$/.test(nextLineText)) { return false; }
+      if (nextColumn.length !== columns.length && nextColumn.length !== columns.length - 1) { return false; }
+      for (i = 0; i < nextColumn.length; i++) {
+        columns[i] = columns[i].replace(/^\s+| +$/, '') + '\n' + nextColumn[i].trim();
+      }
+      rowInfo.extractedTextLinesCount += 1;
+    }
+
     rowInfo.columns = columns.filter(Boolean);
     rowInfo.colspans = countColspan(columns);
 
     token     = state.push('tr_open', 'tr', 1);
-    token.map = [ lineNum, lineNum + 1 ];
+    token.map = [ lineNum, lineNum + rowInfo.extractedTextLinesCount ];
 
-    for (i = 0, col = 0; i < rowInfo.columns.length && col < seperatorInfo.aligns.length;
+    for (i = 0, col = 0; i < rowInfo.columns.length && col < separatorInfo.aligns.length;
                          col += rowInfo.colspans[i], i++) {
       token          = state.push(rowType + '_open', rowType, 1);
-      token.map      = [ lineNum, lineNum + 1 ];
+      token.map      = [ lineNum, lineNum + rowInfo.extractedTextLinesCount ];
       token.attrs    = [];
-      if (seperatorInfo.aligns[col]) {
-        token.attrs.push([ 'style', 'text-align:' + seperatorInfo.aligns[col] ]);
+      if (separatorInfo.aligns[col]) {
+        token.attrs.push([ 'style', 'text-align:' + separatorInfo.aligns[col] ]);
       }
-      if (seperatorInfo.wraps[col]) {
+      if (separatorInfo.wraps[col]) {
         token.attrs.push([ 'class', 'extend' ]);
       }
       if (rowInfo.colspans[i] > 1) {
@@ -123,19 +137,19 @@ module.exports = function multimd_table_plugin(md) {
 
       token          = state.push('inline', '', 0);
       token.content  = rowInfo.columns[i].trim();
-      token.map      = [ lineNum, lineNum + 1 ];
+      token.map      = [ lineNum, lineNum + rowInfo.extractedTextLinesCount ];
       token.children = [];
 
       token          = state.push(rowType + '_close', rowType, -1);
     }
 
-    token     = state.push('tr_close', 'tr', -1);
+    state.push('tr_close', 'tr', -1);
 
     return rowInfo;
   }
 
-  function seperator(state, lineText, lineNum, silent) {
-    var columns, seperatorInfo, i, t;
+  function separator(state, lineText, lineNum, silent) {
+    var columns, separatorInfo, i, t;
 
     // lineText have code indentation
     if (state.sCount[lineNum] - state.blkIndent >= 4) { return false; }
@@ -144,35 +158,35 @@ module.exports = function multimd_table_plugin(md) {
     columns = escapedSplit(lineText.replace(/^\||([^\\])\|$/g, '$1'));
     if (columns.length === 1 && !/^\||[^\\]\|$/.test(lineText)) { return false; }
 
-    seperatorInfo = { aligns: [], wraps: [] };
+    separatorInfo = { aligns: [], wraps: [] };
 
     for (i = 0; i < columns.length; i++) {
       t = columns[i].trim();
       if (!/^:?(-+|=+):?\+?$/.test(t)) { return false; }
 
-      seperatorInfo.wraps.push(t.charCodeAt(t.length - 1) === 0x2B/* + */);
-      if (seperatorInfo.wraps[i]) {
+      separatorInfo.wraps.push(t.charCodeAt(t.length - 1) === 0x2B/* + */);
+      if (separatorInfo.wraps[i]) {
         t = t.slice(0, -1);
       }
 
       switch (((t.charCodeAt(0)            === 0x3A/* : */) << 4) +
                (t.charCodeAt(t.length - 1) === 0x3A/* : */)) {
-        case 0x00: seperatorInfo.aligns.push('');       break;
-        case 0x01: seperatorInfo.aligns.push('right');  break;
-        case 0x10: seperatorInfo.aligns.push('left');   break;
-        case 0x11: seperatorInfo.aligns.push('center'); break;
+        case 0x00: separatorInfo.aligns.push('');       break;
+        case 0x01: separatorInfo.aligns.push('right');  break;
+        case 0x10: separatorInfo.aligns.push('left');   break;
+        case 0x11: separatorInfo.aligns.push('center'); break;
       }
     }
 
-    return silent || seperatorInfo;
+    return silent || separatorInfo;
   }
 
   function table(state, startLine, endLine, silent) {
     /* Regex pseudo code for table:
-     * caption? tableRow+ seperator (tableRow+ | empty)* caption?
+     * caption? tableRow+ separator (tableRow+ | empty)* caption?
      */
-    var seperatorLine, captionAtFirst, captionAtLast, lineText, nextLine,
-        seperatorInfo, token, tableLines, tbodyLines, emptyTBody;
+    var separatorLine, captionAtFirst, captionAtLast, lineText, nextLine,
+        rowInfo, separatorInfo, token, tableLines, tbodyLines, emptyTBody;
 
     if (startLine + 2 > endLine) { return false; }
 
@@ -186,26 +200,24 @@ module.exports = function multimd_table_plugin(md) {
       return false;
     }
 
-    // second line ~ seperator line
+    // second line ~ separator line
     for (nextLine = startLine + 1; nextLine < endLine; nextLine++) {
       lineText = getLine(state, nextLine).trim();
 
-      if (seperator(state, lineText, nextLine, true)) {
-        seperatorLine = nextLine;
+      if (separator(state, lineText, nextLine, true)) {
+        separatorLine = nextLine;
         break;
-      } else if (tableRow(state, lineText, nextLine, true, null, 'th')) {
-        continue;
-      } else {
+      } else if (!tableRow(state, lineText, nextLine, true, null, 'th')) {
         return false;
       }
     }
-    if (!seperatorLine) { return false; }
+    if (!separatorLine) { return false; }
     if (silent) { return true; }
 
     token = state.push('table_open', 'table', 1);
     token.map = tableLines = [ startLine, 0 ];
 
-    seperatorInfo = seperator(state, lineText, seperatorLine, false);
+    separatorInfo = separator(state, lineText, separatorLine, false);
 
     if (captionAtFirst) {
       lineText = getLine(state, startLine).trim();
@@ -213,35 +225,43 @@ module.exports = function multimd_table_plugin(md) {
     }
 
     token     = state.push('thead_open', 'thead', 1);
-    token.map = [ startLine + captionAtFirst, seperatorLine ];
+    token.map = [ startLine + captionAtFirst, separatorLine ];
 
-    for (nextLine = startLine + captionAtFirst; nextLine < seperatorLine; nextLine++) {
+    nextLine = startLine + captionAtFirst;
+    while (nextLine < separatorLine) {
       lineText = getLine(state, nextLine).trim();
-      tableRow(state, lineText, nextLine, false, seperatorInfo, 'th');
+      rowInfo = tableRow(state, lineText, nextLine, false, separatorInfo, 'th');
+      nextLine += rowInfo.extractedTextLinesCount;
     }
 
     token     = state.push('thead_close', 'thead', -1);
 
     token     = state.push('tbody_open', 'tbody', 1);
-    token.map = tbodyLines = [ seperatorLine + 1, 0 ];
+    token.map = tbodyLines = [ separatorLine + 1, 0 ];
     emptyTBody = true;
 
-    for (nextLine = seperatorLine + 1; nextLine < endLine; nextLine++) {
+    nextLine = separatorLine + 1;
+    while (nextLine < endLine) {
       lineText = getLine(state, nextLine).trim();
 
       if (!captionAtFirst && caption(state, lineText, nextLine, true)) {
         captionAtLast = true;
         break;
-      } else if (tableRow(state, lineText, nextLine, false, seperatorInfo, 'td')) {
-        emptyTBody = false;
-      } else if (!emptyTBody && !lineText) {
-        tbodyLines[1] = nextLine - 1;
-        token     = state.push('tbody_close', 'tbody', -1);
-        token     = state.push('tbody_open', 'tbody', 1);
-        token.map = tbodyLines = [ nextLine + 1, 0 ];
-        emptyTBody = true;
       } else {
-        break;
+        rowInfo = tableRow(state, lineText, nextLine, false, separatorInfo, 'td');
+        if (rowInfo) {
+          emptyTBody = false;
+          nextLine += rowInfo.extractedTextLinesCount;
+        } else if (!emptyTBody && !lineText) {
+          tbodyLines[1] = nextLine - 1;
+          token     = state.push('tbody_close', 'tbody', -1);
+          token     = state.push('tbody_open', 'tbody', 1);
+          token.map = tbodyLines = [ nextLine + 1, 0 ];
+          emptyTBody = true;
+          nextLine += 1;
+        } else {
+          break;
+        }
       }
     }
     token = state.push('tbody_close', 'tbody', -1);

--- a/test/fixtures/feature_multilines_row.txt
+++ b/test/fixtures/feature_multilines_row.txt
@@ -4,12 +4,12 @@ Requirement: A backslash at the end of a line indicates that in the cell below
 should be treated as in *the same row*
 
 .
-A       | B
---------|-------
-text    | 1\
-over    | 2\
-several |\
-lines   |
+A         | B
+----------|-------
+text:     | 1\
+- over    | 2\
+- several |\
+- lines   |
 .
 <table>
 <thead>
@@ -20,12 +20,18 @@ lines   |
 </thead>
 <tbody>
 <tr>
-<td>text
-over
-several
-lines</td>
-<td>1
-2</td>
+<td>
+<p>text:</p>
+<ul>
+<li>over</li>
+<li>several</li>
+<li>lines</li>
+</ul>
+</td>
+<td>
+<p>1
+2</p>
+</td>
 </tr>
 </tbody>
 </table>

--- a/test/fixtures/feature_multilines_row.txt
+++ b/test/fixtures/feature_multilines_row.txt
@@ -6,9 +6,9 @@ should be treated as in *the same row*
 .
 A         | B
 ----------|-------
-text:     | 1\
-- over    | 2\
-- several |\
+text:     | 1     \
+- over    | 2     \
+- several |       \
 - lines   |
 .
 <table>
@@ -31,6 +31,34 @@ text:     | 1\
 <td>
 <p>1
 2</p>
+</td>
+</tr>
+</tbody>
+</table>
+.
+
+The colspan feature should still be usable.
+
+.
+A      | B
+-------|-------
+large  |\
+single |\
+row    ||
+.
+<table>
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">
+<p>large
+single
+row</p>
 </td>
 </tr>
 </tbody>

--- a/test/fixtures/feature_multilines_row.txt
+++ b/test/fixtures/feature_multilines_row.txt
@@ -1,0 +1,32 @@
+# Support rows defined on several lines
+
+Requirement: A backslash at the end of a line indicates that in the cell below
+should be treated as in *the same row*
+
+.
+A       | B
+--------|-------
+text    | 1\
+over    | 2\
+several |\
+lines   |
+.
+<table>
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>text
+over
+several
+lines</td>
+<td>1
+2</td>
+</tr>
+</tbody>
+</table>
+.

--- a/test/test.js
+++ b/test/test.js
@@ -32,3 +32,10 @@ describe('Issues', function () {
 
   generate(path.join(__dirname, 'fixtures/issues.txt'), md);
 });
+
+describe('Support rows defined on several lines', function () {
+  var md = require('markdown-it')()
+              .use(require('../'), { enableMultilineRows: true });
+
+  generate(path.join(__dirname, 'fixtures/feature_multilines_row.txt'), md);
+});


### PR DESCRIPTION
This feature can be enabled like this:
```
var md = require('markdown-it')()
              .use(require('markdown-it-multimd-table'), {enableMultilineRows: true});
```

If it is approved, I guess some doc should also be added to the `README`