### PR TITLE
Restore token context in multiline blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,8 +330,8 @@ module.exports = function multimd_table_plugin(md, options) {
             blToken = blockTokens[t];
             blToken.level = trToken.level + 1;
             if (blToken.map && trToken.map) {
-              blToken.map[0] = blToken.map[0] + trToken.map[0];
-              blToken.map[1] = blToken.map[1] + trToken.map[0];
+              blToken.map[0] += trToken.map[0];
+              blToken.map[1] += trToken.map[0];
             }
             state.tokens.push(blToken);
           }
@@ -339,6 +339,7 @@ module.exports = function multimd_table_plugin(md, options) {
           token          = state.push('inline', '', 0);
           token.content  = text.trim();
           token.map      = trToken.map;
+          token.level    = trToken.level + 1;
           token.children = [];
         }
 


### PR DESCRIPTION
When using `state.md.block.parse` it loses all context as to where the tokens are placed within a document. Notably, level and map which represent token nesting level and source line number respectively. 

This PR stores the created tokens temporarily so that the context can be added back manually before pushing the tokens onto the state. 
I did my best to follow the projects style, but please let me know if you have any requested changes, I'd be more than happy to change this to how you see fit. I also didn't see how this change could fit into the current testing framework, so there are no tests for now. 