### PR TITLE
Remove markdown-it as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "scripts": {
     "test": "make test"
   },
-  "dependencies": {
-    "markdown-it": "^12.3.2"
-  },
   "devDependencies": {
     "browserify": "^16.3.0",
     "coveralls": "^3.0.4",


### PR DESCRIPTION
The markdown-it package is not actually a dependency but more like a related runtime, and having it there are a dependency means that a specific version of markdown-it is going to be installed even if it's not used by the project (which may use a different version of markdown-it).

See [this commit](https://github.com/laurent22/joplin/pull/6059/files) for example, which adds markdown-it@12.3.2 via the multi-md plugin, even though we already have markdown-it and aren't going to use that specific version.

Other plugins either don't have the dependency or make it a peer dependency. Personally I feel peer dependencies add unnecessary restrictions by requiring a specific package version, when other versions might work just as well, and that cause issues when upgrading packages. So I feel it's better to simply remove the dependency