### PR TITLE
Add "caption-side" CSS depending on whether the caption is below or above table

### DIFF
--- a/index.js
+++ b/index.js
@@ -267,10 +267,20 @@ module.exports = function multimd_table_plugin(md, options) {
       token          = state.push('caption_open', 'caption', 1);
       token.map      = tableToken.meta.cap.map;
 
+      var attrs      = [];
+      var capSide    = tableToken.meta.cap.first ? 'top' : 'bottom';
+
       /* Null is possible when disabled the option autolabel */
       if (tableToken.meta.cap.label !== null) {
-        token.attrs    = [ [ 'id', tableToken.meta.cap.label ] ];
+        attrs.push([ 'id', tableToken.meta.cap.label ]);
       }
+
+      /* Add caption-side inline-CSS to <caption> tag, if caption is below the markdown table. */
+      if (capSide !== 'top') {
+        attrs.push([ 'style', 'caption-side: ' + capSide ]);
+      }
+
+      token.attrs    = attrs;
 
       token          = state.push('inline', '', 0);
       token.content  = tableToken.meta.cap.text;

--- a/test/fixtures/options.txt
+++ b/test/fixtures/options.txt
@@ -612,7 +612,7 @@ Table not labeled with autolabel disabled
 [nolabel]
 .
 <table>
-<caption>nolabel</caption>
+<caption style="caption-side: bottom">nolabel</caption>
 <tbody>
 <tr>
 <td>1</td>

--- a/test/fixtures/standard.txt
+++ b/test/fixtures/standard.txt
@@ -485,7 +485,7 @@ Content       |   **Cell**    |         Cell |
 [             |               |              ]
 .
 <table>
-<caption id="">             |               |              </caption>
+<caption id="" style="caption-side: bottom">             |               |              </caption>
 <thead>
 <tr>
 <th></th>
@@ -606,7 +606,7 @@ Content       |                             ||
 [Prototype table]
 .
 <table>
-<caption id="prototypetable">Prototype table</caption>
+<caption id="prototypetable" style="caption-side: bottom">Prototype table</caption>
 <thead>
 <tr>
 <th></th>
@@ -648,7 +648,7 @@ And more      | With an escaped '\|'         ||
 [Prototype table]
 .
 <table>
-<caption id="prototypetable">Prototype table</caption>
+<caption id="prototypetable" style="caption-side: bottom">Prototype table</caption>
 <thead>
 <tr>
 <th></th>

--- a/test/fixtures/unspecified.txt
+++ b/test/fixtures/unspecified.txt
@@ -299,7 +299,7 @@ a|table
 [repo]: https://github.com/redbug312/markdown-it-multimd-table
 .
 <table>
-<caption id="captionallowsboldorlinkrepo">caption allows <strong>bold</strong> or <a href="https://github.com/redbug312/markdown-it-multimd-table">link</a></caption>
+<caption id="captionallowsboldorlinkrepo" style="caption-side: bottom">caption allows <strong>bold</strong> or <a href="https://github.com/redbug312/markdown-it-multimd-table">link</a></caption>
 <thead>
 <tr>
 <th>make</th>
@@ -325,7 +325,7 @@ a|table
 [repo]: https://github.com/redbug312/markdown-it-multimd-table
 .
 <table>
-<caption id="labeled">caption allows <strong>bold</strong> or <a href="https://github.com/redbug312/markdown-it-multimd-table">link</a></caption>
+<caption id="labeled" style="caption-side: bottom">caption allows <strong>bold</strong> or <a href="https://github.com/redbug312/markdown-it-multimd-table">link</a></caption>
 <thead>
 <tr>
 <th>make</th>


### PR DESCRIPTION
### Description

Currently, whether a caption is placed above or below the table in Markdown isn't really taken into account. The resulting caption stays on top.

This pull request adds a style attribute to the &lt;caption&gt; tag, containing `caption-side: bottom`, if the caption is placed below the table.  
(The default value of `caption-side` is `top`, which is why I chose to omit it. See [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/caption-side))

I also updated the test fixtures to include the style attribute.

Please let me know, if there's something wrong with the PR.

### Examples

```
| Example table ||
|----------------|
|  Foo  |  Bar   |
[Caption below]
```

Results in

![grafik](https://user-images.githubusercontent.com/47528453/226549902-e4cf026f-b4a6-4ced-8fa1-1a8fa7adfa80.png)

```
[Caption above]
| Example table ||
|----------------|
|  Foo  |  Bar   |
```

Results in

![grafik](https://user-images.githubusercontent.com/47528453/226550087-0f2a328e-22eb-4fb9-af09-6c286138652c.png)
