### PR TITLE
Fixup minor typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var md = require('markdown-it')()
               rowspan:    false,
               headerless: false,
               multibody:  true,
-              aotolabel:  true,
+              autolabel:  true,
             });
 
 md.render(/*...*/)


### PR DESCRIPTION
This PR just fixes up a minor type in the readme
`aotolabel` → `autolabel`