### PR TITLE
fix export in index.d.ts for typescript using esm

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,4 +6,5 @@ interface Options {
   multibody: boolean;
   autolabel: boolean;
 }
-export default function multimd_table_plugin(md: MarkdownIt, options?: Partial<Options>): void;
+declare function multimd_table_plugin(md: MarkdownIt, options?: Partial<Options>): void;
+export = multimd_table_plugin;


### PR DESCRIPTION
"export default" in type definition is not correct.

To use this plugin in the typescript environment using esm, module have to exported by "export = ".

Detailed explanation is there.
https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseExportDefault.md